### PR TITLE
Remove trailing characters from package description line

### DIFF
--- a/runner.el
+++ b/runner.el
@@ -1,4 +1,4 @@
-;;; runner.el --- improved "open with" suggestions for dired ---
+;;; runner.el --- Improved "open with" suggestions for dired
 
 ;; Author: Thamer Mahmoud <thamer.mahmoud@gmail.com>
 ;; Version: 1.2


### PR DESCRIPTION
Without these changes, "---" will be in the description of any generated ELPA package.
